### PR TITLE
Add solar collector parameters

### DIFF
--- a/custom_components/ha_oekofen/const.py
+++ b/custom_components/ha_oekofen/const.py
@@ -87,8 +87,7 @@ TIME_SENSORS_BY_DOMAIN = {
 
 # Unit: %
 NON_PUMP_PERCENTAGE_SENSORS_BY_DOMAIN = {
-    'pe': ['L_currentairflow', 'L_fluegas', 'L_uw_speed', 'L_uw', 'L_modulation'],
-    'sk': ['L_pump'],
+    'pe': ['L_currentairflow', 'L_fluegas', 'L_uw_speed', 'L_uw', 'L_modulation']
 }
 
 NON_PUMP_BINARY_SENSORS_BY_DOMAIN = {

--- a/custom_components/ha_oekofen/const.py
+++ b/custom_components/ha_oekofen/const.py
@@ -35,6 +35,7 @@ L_PUMP_BINARY_SENSORS_BY_DOMAIN = {
     # 'pu',  # is % not bool
     'ww': ['L_pump'],
     'circ': ['L_pummp'],
+    'sk': ['L_pump'],
 }
 
 PUMP_PERCENTAGE_SENSORS_BY_DOMAIN = {
@@ -49,6 +50,7 @@ TEMP_SENSORS_BY_DOMAIN = {
     'ww': ['L_temp_set', 'L_ontemp_act', 'L_offtemp_act'],
     'circ': ['L_ret_temp', 'L_release_temp'],
     'pe': ['L_temp_act', 'L_temp_set', 'L_ext_temp', 'L_frt_temp_act', 'L_frt_temp_set', 'L_frt_temp_end', 'L_uw_release'],
+    'sk': ['L_koll_temp', 'spu_max']
 }
 
 STATE_SENSORS_BY_DOMAIN = {
@@ -56,7 +58,8 @@ STATE_SENSORS_BY_DOMAIN = {
     #'thirdparty': 'L_state',
     'pu': 'L_statetext',
     'ww': 'L_statetext',
-    'pe': 'L_statetext'
+    'pe': 'L_statetext',
+    'sk': 'L_statetext'
 }
 
 #
@@ -85,6 +88,10 @@ TIME_SENSORS_BY_DOMAIN = {
 # Unit: %
 NON_PUMP_PERCENTAGE_SENSORS_BY_DOMAIN = {
     'pe': ['L_currentairflow', 'L_fluegas', 'L_uw_speed', 'L_uw', 'L_modulation']
+}
+
+NON_PUMP_BINARY_SENSORS_BY_DOMAIN = {
+    'sk': ['L_pump', 'cooling', 'mode'],
 }
 
 WEIGHT_SENSORS_BY_DOMAIN = {

--- a/custom_components/ha_oekofen/const.py
+++ b/custom_components/ha_oekofen/const.py
@@ -91,7 +91,7 @@ NON_PUMP_PERCENTAGE_SENSORS_BY_DOMAIN = {
 }
 
 NON_PUMP_BINARY_SENSORS_BY_DOMAIN = {
-    'sk': ['L_pump', 'cooling', 'mode'],
+    'sk': ['mode'],
 }
 
 WEIGHT_SENSORS_BY_DOMAIN = {

--- a/custom_components/ha_oekofen/const.py
+++ b/custom_components/ha_oekofen/const.py
@@ -87,7 +87,8 @@ TIME_SENSORS_BY_DOMAIN = {
 
 # Unit: %
 NON_PUMP_PERCENTAGE_SENSORS_BY_DOMAIN = {
-    'pe': ['L_currentairflow', 'L_fluegas', 'L_uw_speed', 'L_uw', 'L_modulation']
+    'pe': ['L_currentairflow', 'L_fluegas', 'L_uw_speed', 'L_uw', 'L_modulation'],
+    'sk': ['L_pump'],
 }
 
 NON_PUMP_BINARY_SENSORS_BY_DOMAIN = {

--- a/custom_components/ha_oekofen/sensor.py
+++ b/custom_components/ha_oekofen/sensor.py
@@ -17,7 +17,8 @@ from .entity import OekofenHKSensorEntity, \
     get_zs_description, \
     get_total_hour_description, \
     get_total_minute_description, \
-    get_weight_description, get_binary_description
+    get_weight_description, \
+    get_binary_description
 
 
 async def async_setup_entry(

--- a/custom_components/ha_oekofen/sensor.py
+++ b/custom_components/ha_oekofen/sensor.py
@@ -17,7 +17,7 @@ from .entity import OekofenHKSensorEntity, \
     get_zs_description, \
     get_total_hour_description, \
     get_total_minute_description, \
-    get_weight_description
+    get_weight_description, get_binary_description
 
 
 async def async_setup_entry(
@@ -101,6 +101,20 @@ async def async_setup_entry(
                     coordinator=coordinator,
                     oekofen_entity=ha_oekofen,
                     entity_description=percent_descr,
+                )
+                entities.append(mod_entity)
+
+    # Non Pump binary sensors by domain
+    for domain_name, attribute_names in const.WEIGHT_SENSORS_BY_DOMAIN.items():
+        domain_indexes = ha_oekofen.api.data.get(f'{domain_name}_indexes')
+        for domain_index in domain_indexes:
+            for attribute_name in attribute_names:
+                binary_descr = get_binary_description(domain_name=domain_name, domain_index=domain_index,
+                                                      attribute_key=attribute_name)
+                mod_entity = OekofenHKSensorEntity(
+                    coordinator=coordinator,
+                    oekofen_entity=ha_oekofen,
+                    entity_description=binary_descr,
                 )
                 entities.append(mod_entity)
 


### PR DESCRIPTION
I have a solar collector with the following fields:
```json
"sk1":{
  "L_koll_temp": 171,
  "L_spu": 419,
  "L_pump": 0,
  "L_state": 32,
  "L_statetext": "Differenz Kollektor-Speicher zu niedrig",
  "mode": 1,
  "cooling": 0,
  "spu_max": 800,
  "name": ""
},
``` 
I added the majority of the values in to the existing lists. 
I also added a NON_PUMP_BINARY_SENSORS_BY_DOMAIN  section. 
